### PR TITLE
Temporary removed outdated feed

### DIFF
--- a/regions/us-me-portland.json
+++ b/regions/us-me-portland.json
@@ -75,7 +75,6 @@
   "currency": "USD",
   "trafficRule": "right",
   "feeds": [
-    "us-greaterportlandmetro",
-    "us-southportlandbus"
+    "us-greaterportlandmetro"
   ]
 }


### PR DESCRIPTION
Removed the South Portland Bus feed fot the region, as its fed was outdated and caused the build to fail